### PR TITLE
fix(exclude): exclude paths with a file extension

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 const axios = require('axios')
 const NodeCache = require('node-cache')
+const path = require('path')
 
 const PROJECT_CACHE_TTL = 60 * 60 * 24 // 24 Hours
 const LANGUAGE_CACHE_TTL = 60 * 10 // 10 Minutes
@@ -80,6 +81,10 @@ module.exports = (projectToken, ttl = LANGUAGE_CACHE_TTL) => {
   })
 
   return async (req, res, next) => {
+    if (path.extname(req.path)) {
+      return next()
+    }
+
     const { wti_locale: locale } = req.headers
     const key = `WTI::TRANSLATIONS::${locale}`
 
@@ -93,6 +98,6 @@ module.exports = (projectToken, ttl = LANGUAGE_CACHE_TTL) => {
 
     req.translations = cachedVal || data
 
-    next()
+    return next()
   }
 }


### PR DESCRIPTION
Exclude setting translations object to requests for files with an extension 
eg images, js files etc. 

This will make most requests smaller and might reduce the calls to the WTI api after a server restart
